### PR TITLE
ASC-995 Remove Deprecated Method Calls

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 pip<10.0.0
+pytest~=3.6
 rpc-zigzag~=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 python_requirements = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-requirements = ['pytest>=3.5.0', 'setuptools', 'sh', 'rpc-zigzag~=0.12.0']
+requirements = ['pytest~=3.6', 'setuptools', 'sh', 'rpc-zigzag~=0.12.0']
 packages = ['pytest_zigzag']
 entry_points = {
     'pytest11': [


### PR DESCRIPTION
Removed calls to "item.get_marker" and replaced with supported methods. The
"item.iter_markers" method returns a generator so I had to remove the list
comprehension.

See https://docs.pytest.org/en/latest/mark.html#updating-code