### PR TITLE
ASC-1276 Implement Config for CI Environment Capture

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.rst
 include HISTORY.rst
+recursive-include pytest_zigzag/data *
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
+jsonschema~=2.6
 pip<10.0.0
 pytest~=3.6
 rpc-zigzag~=0.12.0

--- a/pytest_zigzag/data/configs/asc-config.json
+++ b/pytest_zigzag/data/configs/asc-config.json
@@ -1,0 +1,20 @@
+{
+  "environment_variables": [
+    "BUILD_URL",
+    "BUILD_NUMBER",
+    "RE_JOB_ACTION",
+    "RE_JOB_IMAGE",
+    "RE_JOB_SCENARIO",
+    "RE_JOB_BRANCH",
+    "RPC_RELEASE",
+    "RPC_PRODUCT_RELEASE",
+    "OS_ARTIFACT_SHA",
+    "PYTHON_ARTIFACT_SHA",
+    "APT_ARTIFACT_SHA",
+    "REPO_URL",
+    "JOB_NAME",
+    "MOLECULE_TEST_REPO",
+    "MOLECULE_SCENARIO_NAME",
+    "MOLECULE_GIT_COMMIT"
+  ]
+}

--- a/pytest_zigzag/data/configs/jenkins-config.json
+++ b/pytest_zigzag/data/configs/jenkins-config.json
@@ -1,0 +1,23 @@
+{
+  "environment_variables":  [
+    "BUILD_NUMBER",
+    "BUILD_ID",
+    "BUILD_URL",
+    "NODE_NAME",
+    "JOB_NAME",
+    "BUILD_TAG",
+    "JENKINS_URL",
+    "EXECUTOR_NUMBER",
+    "JAVA_HOME",
+    "WORKSPACE",
+    "SVN_REVISION",
+    "CVS_BRANCH",
+    "GIT_COMMIT",
+    "GIT_URL",
+    "GIT_BRANCH",
+    "PROMOTED_URL",
+    "PROMOTED_JOB_NAME",
+    "PROMOTED_NUMBER",
+    "PROMOTED_ID"
+  ]
+}

--- a/pytest_zigzag/data/configs/mk8s-config.json
+++ b/pytest_zigzag/data/configs/mk8s-config.json
@@ -1,0 +1,33 @@
+{
+  "environment_variables": [
+    "BUILD_URL",
+    "BUILD_NUMBER",
+    "BUILD_ID",
+    "NODE_NAME",
+    "JOB_NAME",
+    "BUILD_TAG",
+    "JENKINS_URL",
+    "EXECUTOR_NUMBER",
+    "WORKSPACE",
+    "CVS_BRANCH",
+    "GIT_COMMIT",
+    "GIT_URL",
+    "GIT_BRANCH",
+    "GIT_LOCAL_BRANCH",
+    "GIT_AUTHOR_NAME",
+    "GIT_AUTHOR_EMAIL",
+    "BRANCH_NAME",
+    "CHANGE_AUTHOR_DISPLAY_NAME",
+    "CHANGE_AUTHOR",
+    "CHANGE_BRANCH",
+    "CHANGE_FORK",
+    "CHANGE_ID",
+    "CHANGE_TARGET",
+    "CHANGE_TITLE",
+    "CHANGE_URL",
+    "JOB_URL",
+    "NODE_LABELS",
+    "PWD",
+    "STAGE_NAME"
+  ]
+}

--- a/pytest_zigzag/data/schema/pytest-zigzag-config.schema.json
+++ b/pytest_zigzag/data/schema/pytest-zigzag-config.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "pytest-zigzag-config",
+  "description": "A JSON schema for pytest-zigzag configuration files.",
+  "type": "object",
+  "required": ["environment_variables"],
+  "properties": {
+    "environment_variables": {
+      "description": "A white list of environment variables to extract and include in the JUnitXML global properties.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 bumpversion
 flake8
 ipython
+jsonschema
 lxml
 python-dateutil
 pytest

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 python_requirements = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-requirements = ['pytest~=3.6', 'setuptools', 'sh', 'rpc-zigzag~=0.12.0']
+requirements = ['pytest~=3.6', 'setuptools', 'sh', 'rpc-zigzag~=0.12.0', 'jsonschema~=2.6']
 packages = ['pytest_zigzag']
 entry_points = {
     'pytest11': [

--- a/tests/test_custom_config.py
+++ b/tests/test_custom_config.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
-
 # ======================================================================================================================
 # Imports
 # ======================================================================================================================
 from __future__ import absolute_import
-from tests.conftest import run_and_parse_with_config
-from tests.conftest import JunitXml
 import re
+from tests.conftest import JunitXml
+from tests.conftest import run_and_parse_with_config
 
 
 # ======================================================================================================================
@@ -146,7 +145,8 @@ ci-environment=foobar
         f.write(config)
 
     result = testdir.runpytest("--junitxml={}".format(result_path), "-c={}".format(config_path))
+    assert result.ret == 1
 
     out_lines = [str(x) for x in result.outlines]
-    expected_error = re.compile('.*RuntimeError: The value foobar is not a valid value.*')
+    expected_error = re.compile(".*Exit: The value 'foobar' is not a valid value.*")
     assert any(re.match(expected_error, x) for x in out_lines)

--- a/tests/test_pytest_zigzag_config.py
+++ b/tests/test_pytest_zigzag_config.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+# ======================================================================================================================
+# Imports
+# ======================================================================================================================
+from __future__ import absolute_import
+import pytest
+from json import dump
+# noinspection PyProtectedMember
+from _pytest.outcomes import Exit
+# noinspection PyProtectedMember
+from pytest_zigzag import _load_config_file
+
+
+# ======================================================================================================================
+# Fixtures
+# ======================================================================================================================
+@pytest.fixture(scope='module')
+def invalid_pytest_zigzag_json_config(tmpdir_factory):
+    """Create an invalid 'pytest-zigzag-config' on disk.
+
+    Args:
+        tmpdir_factory (_pytest.tmpdir.TempdirFactory): Create a temp directory.
+
+    Returns:
+        str: Path to config file.
+    """
+
+    config = {
+        "not_quite_right":
+            [
+                "var1",
+                "var2",
+                "var3"
+            ]
+    }
+
+    config_path = tmpdir_factory.mktemp('data').join('invalid_config.json').strpath
+    with open(str(config_path), 'w') as f:
+        dump(config, f)
+
+    return config_path
+
+
+@pytest.fixture(scope='module')
+def invalid_json_file(tmpdir_factory):
+    """Create an invalid JSON on disk.
+
+    Args:
+        tmpdir_factory (_pytest.tmpdir.TempdirFactory): Create a temp directory.
+
+    Returns:
+        str: Path to config file.
+    """
+
+    config_path = tmpdir_factory.mktemp('data').join('invalid.json').strpath
+    with open(str(config_path), 'w') as f:
+        f.write('!!!!This is not valid json!!!!!')
+
+    return config_path
+
+
+# ======================================================================================================================
+# Tests
+# ======================================================================================================================
+def test_invalid_config_file(invalid_pytest_zigzag_json_config):
+    """Verify that config files that do not comply with the schema are rejected.
+
+    Args:
+        invalid_pytest_zigzag_json_config (str): Path to config file.
+    """
+
+    # Expect
+    error_msg = 'does not comply with schema:'
+
+    # Test
+    with pytest.raises(Exit) as e:
+        _load_config_file(invalid_pytest_zigzag_json_config)
+
+    assert error_msg in str(e)
+
+
+def test_invalid_json_config_file(invalid_json_file):
+    """Verify that config files that do not contain valid JSON are rejected.
+
+    Args:
+        invalid_json_file (str): Path to config file.
+    """
+
+    # Expect
+    error_msg = 'file is not valid JSON'
+
+    # Test
+    with pytest.raises(Exit) as e:
+        _load_config_file(invalid_json_file)
+
+    assert error_msg in str(e)
+
+
+def test_invalid_config_file_path():
+    """Verify that an invalid config file path is rejected."""
+
+    # Expect
+    error_msg = 'Failed to load'
+
+    # Test
+    with pytest.raises(Exit) as e:
+        _load_config_file('/path/does/not/exist')
+
+    assert error_msg in str(e)

--- a/tests/test_testsuite.py
+++ b/tests/test_testsuite.py
@@ -7,8 +7,14 @@
 # ======================================================================================================================
 from __future__ import absolute_import
 import os
-from pytest_zigzag import ASC_ENV_VARS
+# noinspection PyProtectedMember
+from pytest_zigzag import _load_config_file
 from tests.conftest import run_and_parse, is_sub_dict
+
+# ======================================================================================================================
+# Globals
+# ======================================================================================================================
+ASC_TEST_ENV_VARS = list(_load_config_file('asc')['environment_variables'])      # Shallow copy.
 
 
 # ======================================================================================================================
@@ -25,7 +31,7 @@ def test_no_env_vars_set(testdir, undecorated_test_function, testsuite_attribs_e
     # Test
     assert is_sub_dict(testsuite_attribs_exp, junit_xml.testsuite_attribs)
 
-    for env_var in ASC_ENV_VARS:
+    for env_var in ASC_TEST_ENV_VARS:
         assert junit_xml.testsuite_props[env_var] == 'Unknown'
 
 
@@ -35,7 +41,7 @@ def test_env_vars_set(testdir, undecorated_test_function, testsuite_attribs_exp)
     # Setup
     testdir.makepyfile(undecorated_test_function.format(test_name='test_pass'))
 
-    for env in ASC_ENV_VARS:
+    for env in ASC_TEST_ENV_VARS:
         os.environ[env] = env
 
     junit_xml = run_and_parse(testdir)
@@ -43,6 +49,6 @@ def test_env_vars_set(testdir, undecorated_test_function, testsuite_attribs_exp)
     # Test
     assert is_sub_dict(testsuite_attribs_exp, junit_xml.testsuite_attribs)
 
-    expected = {env: env for env in ASC_ENV_VARS}
+    expected = {env: env for env in ASC_TEST_ENV_VARS}
     expected['ci-environment'] = 'asc'  # This is not supplied by the environment
     assert junit_xml.testsuite_props == expected

--- a/tests/test_xsd.py
+++ b/tests/test_xsd.py
@@ -7,16 +7,18 @@
 # ======================================================================================================================
 from __future__ import absolute_import
 from lxml import etree
-from pytest_zigzag import MK8S_ENV_VARS, ASC_ENV_VARS
+# noinspection PyProtectedMember
+from pytest_zigzag import _load_config_file
 # noinspection PyPackageRequirements
 from zigzag.xml_parsing_facade import XmlParsingFacade
 from tests.conftest import run_and_parse
 from tests.conftest import run_and_parse_with_config
+
 # ======================================================================================================================
 # Globals
 # ======================================================================================================================
-TEST_ENV_VARS = list(ASC_ENV_VARS)      # Shallow copy.
-MK8S_TEST_ENV_VARS = list(MK8S_ENV_VARS)      # Shallow copy.
+ASC_TEST_ENV_VARS = list(_load_config_file('asc')['environment_variables'])      # Shallow copy.
+MK8S_TEST_ENV_VARS = list(_load_config_file('mk8s')['environment_variables'])      # Shallow copy.
 
 
 # ======================================================================================================================
@@ -35,6 +37,7 @@ def test_happy_path_asc(testdir, properly_decorated_test_function, mocker):
                                                                jira_id='ASC-123'))
 
     xml_doc = run_and_parse(testdir).xml_doc
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd()))
 
     # Test
@@ -59,6 +62,7 @@ ci-environment=mk8s
 """  # noqa
 
     xml_doc = run_and_parse_with_config(testdir, config).xml_doc
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
     # Test
@@ -84,6 +88,7 @@ def test_multiple_jira_references(testdir, mocker):
     """)
 
     xml_doc = run_and_parse(testdir).xml_doc
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd()))
 
     # Test
@@ -109,6 +114,7 @@ def test_multiple_jira_references_mk8s(testdir, mocker):
     """)
 
     xml_doc = run_and_parse(testdir).xml_doc
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
     # Test
@@ -128,6 +134,7 @@ def test_missing_required_marks_asc(testdir, undecorated_test_function, mocker):
     testdir.makepyfile(undecorated_test_function.format(test_name='test_typo_global'))
 
     xml_doc = run_and_parse(testdir).xml_doc
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('asc')))
 
     # Test
@@ -147,6 +154,7 @@ def test_missing_required_marks_mk8s(testdir, undecorated_test_function, mocker)
     testdir.makepyfile(undecorated_test_function.format(test_name='test_typo_global'))
 
     xml_doc = run_and_parse(testdir).xml_doc
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
     # Test
@@ -171,6 +179,7 @@ def test_extra_testcase_property_asc(testdir, properly_decorated_test_function, 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties').append(etree.Element('property',
                                                                attrib={'name': 'extra', 'value': 'fail'}))
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('asc')))
 
     # Test
@@ -195,6 +204,7 @@ def test_extra_testcase_property_mk8s(testdir, properly_decorated_test_function,
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties').append(etree.Element('property',
                                                                attrib={'name': 'extra', 'value': 'fail'}))
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
     # Test
@@ -218,6 +228,7 @@ def test_typo_property_asc(testdir, properly_decorated_test_function, mocker):
 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties/property').attrib['name'] = 'wrong_test_id'
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('asc')))
 
     # Test
@@ -241,6 +252,7 @@ def test_typo_property_mk8s(testdir, properly_decorated_test_function, mocker):
 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties/property').attrib['name'] = 'wrong_test_id'
+    # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd()))
 
     # Test


### PR DESCRIPTION
Currently the supported CI environments ('asc', 'mk8s') are hardcoded which
is problematic. This commit adds a JSON config file for defining CI
environments which will allow for end user customization.

Note: this is a partial implementation and only replaces the hardcoded CI
environments with config files.