### PR TITLE
ASC-1208 Ensure QTEST_API_TOKEN is alphanum

### DIFF
--- a/pytest_zigzag/__init__.py
+++ b/pytest_zigzag/__init__.py
@@ -5,6 +5,7 @@
 # ======================================================================================================================
 from __future__ import absolute_import
 import os
+import re
 import pytest
 from datetime import datetime
 # noinspection PyPackageRequirements
@@ -132,6 +133,10 @@ def _get_option_of_highest_precedence(config, option_name):
     return highest_precedence
 
 
+def _validate_qtest_token(token):
+    return token if re.match("^[a-zA-Z0-9]+$", token) else ""
+
+
 # ======================================================================================================================
 # Hooks
 # ======================================================================================================================
@@ -151,7 +156,9 @@ def pytest_sessionfinish(session):
             try:
                 junit_file_path = getattr(session.config, '_xml', None).logfile
                 # noinspection PyTypeChecker
-                zz = ZigZag(junit_file_path, os.environ['QTEST_API_TOKEN'], qtest_project_id, None)
+                # validate token
+                token = _validate_qtest_token(os.environ['QTEST_API_TOKEN'])
+                zz = ZigZag(junit_file_path, token, qtest_project_id, None)
                 job_id = zz.upload_test_results()
                 SESSION_MESSAGES.append("ZigZag upload was successful!")
                 SESSION_MESSAGES.append("Queue Job ID: {}".format(job_id))

--- a/tests/test_using_zigzag_inside_pytest.py
+++ b/tests/test_using_zigzag_inside_pytest.py
@@ -16,7 +16,7 @@ def test_zigzag_happy_path(testdir, single_decorated_test_function, mocker):
     test_id_exp = '123e4567-e89b-12d3-a456-426655440000'
     test_name_exp = 'test_uuid'
     project_id = '12345'
-    env_vars = {'QTEST_API_TOKEN': 'valid_token'}
+    env_vars = {'QTEST_API_TOKEN': 'validtoken'}
     testdir.makepyfile(single_decorated_test_function.format(mark_type=mark_type_exp,
                                                              mark_arg=test_id_exp,
                                                              test_name=test_name_exp))
@@ -73,7 +73,7 @@ def test_zigzag_no_project_id(testdir, single_decorated_test_function, mocker):
     mark_type_exp = 'test_id'
     test_id_exp = '123e4567-e89b-12d3-a456-426655440000'
     test_name_exp = 'test_uuid'
-    env_vars = {'QTEST_API_TOKEN': 'valid_token'}
+    env_vars = {'QTEST_API_TOKEN': 'validtoken'}
     testdir.makepyfile(single_decorated_test_function.format(mark_type=mark_type_exp,
                                                              mark_arg=test_id_exp,
                                                              test_name=test_name_exp))
@@ -101,7 +101,7 @@ def test_no_zigzag(testdir, single_decorated_test_function, mocker):
     test_id_exp = '123e4567-e89b-12d3-a456-426655440000'
     test_name_exp = 'test_uuid'
     project_id = '12345'
-    env_vars = {'QTEST_API_TOKEN': 'valid_token'}
+    env_vars = {'QTEST_API_TOKEN': 'validtoken'}
     testdir.makepyfile(single_decorated_test_function.format(mark_type=mark_type_exp,
                                                              mark_arg=test_id_exp,
                                                              test_name=test_name_exp))


### PR DESCRIPTION
This commit adds a method to sanitize the input from the QTEST_API_TOKEN
to ensure that it contains only alphanumeric characters.

The unit tests have been updated accordingly to conform to this
standard.