### PR TITLE
ASC-690 fix no end_time scenario

### DIFF
--- a/pytest_zigzag/__init__.py
+++ b/pytest_zigzag/__init__.py
@@ -217,6 +217,7 @@ def pytest_runtest_setup(item):
 
     now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     item.user_properties.append(('start_time', now))
+    item.user_properties.append(('end_time', now))  # will override if we get to teardown
 
     if "test_case_with_steps" in item.keywords and 'setup' not in item.name and 'teardown' not in item.name:
         previousfailed = getattr(item.parent, "_previousfailed", None)
@@ -232,8 +233,18 @@ def pytest_runtest_teardown(item):
         item (_pytest.nodes.Item): An item object.
     """
 
-    now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-    item.user_properties.append(('end_time', now))
+    now_tup = ('end_time', datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+    position = None
+
+    # find the position of end_time tuple
+    for n, tup in enumerate(item.user_properties):
+        if tup[0] == 'end_time':
+            position = n
+
+    if position is not None:
+        item.user_properties[position] = now_tup
+    else:
+        item.user_properties.append(now_tup)
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,3 +418,47 @@ def sleepy_test_function():
         """
 
     return py_file
+
+
+@pytest.fixture(scope='session')
+def failure_in_test_setup():
+    """A Python function that has a fixture that fails setup with the following named formatters:
+
+        test_name: Name of the test_function
+    """
+
+    py_file = \
+        """
+        import pytest
+        @pytest.fixture(scope='function')
+        def my_test_fixture():
+            assert False
+            yield
+            pass
+        def {test_name}(my_test_fixture):
+            pass
+        """
+
+    return py_file
+
+
+@pytest.fixture(scope='session')
+def failure_in_test_teardown():
+    """A Python function that has a fixture that fails teardown with the following named formatters:
+
+        test_name: Name of the test_function
+    """
+
+    py_file = \
+        """
+        import pytest
+        @pytest.fixture(scope='function')
+        def my_test_fixture():
+            pass
+            yield
+            assert False
+        def {test_name}(my_test_fixture):
+            pass
+        """
+
+    return py_file

--- a/tests/test_testcase.py
+++ b/tests/test_testcase.py
@@ -227,3 +227,41 @@ def test_accurate_test_time(testdir, sleepy_test_function):
     end = date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'end_time')[0]))
 
     assert (end - start).seconds == sleep_seconds_exp
+
+
+@pytest.mark.skipif('SKIP_LONG_RUNNING_TESTS' in os.environ, reason='Impatient developer is impatient')
+def test_failure_in_setup_fixture(testdir, failure_in_test_setup):
+    """Verify that we still get start and end time if test fails setup fixture"""
+
+    # Expect
+    test_name_exp = 'test_oops_i_failed_my_setup'
+
+    # Setup
+    testdir.makepyfile(failure_in_test_setup.format(test_name=test_name_exp))
+
+    junit_xml = run_and_parse(testdir, 1)
+
+    try:
+        date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'start_time')[0]))
+        date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'end_time')[0]))
+    except IndexError:
+        raise AssertionError('Could not find start_time and end_time')
+
+
+@pytest.mark.skipif('SKIP_LONG_RUNNING_TESTS' in os.environ, reason='Impatient developer is impatient')
+def test_failure_in_teardown_fixture(testdir, failure_in_test_teardown):
+    """Verify that we still get start and end time if test fails teardown fixture"""
+
+    # Expect
+    test_name_exp = 'test_oops_i_failed_my_teardown'
+
+    # Setup
+    testdir.makepyfile(failure_in_test_teardown.format(test_name=test_name_exp))
+
+    junit_xml = run_and_parse(testdir, 1)
+
+    try:
+        date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'start_time')[0]))
+        date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'end_time')[0]))
+    except IndexError:
+        raise AssertionError('Could not find start_time and end_time')


### PR DESCRIPTION
- adds 'end_time' in pytest_runtest_setup
- overrides 'end_time' in pytest_runtest_teardown
- adds tests for failure in teardown and failure in setup