### PR TITLE
MAINT update json schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,9 @@ Configuration
 ^^^^^^^^^^^^^
 
 You can supply a json config to this plugin containing a dictionary. Each key / value will become a property name and
-value on the test suite node of the resulting xml. There are two required config properties: BUILD_URL and BUILD_NUMBER.
-These can have null values, but they must exist.
+value on the test suite node of the resulting xml. There is one required config: pytest_zigzag_env_vars.
+This should be a json object that that where the keys are the environment variable names to be collected, if you set
+value to a string that value will be used.  If the value is null it will be pulled from the environment.
 
 The location of the config file can be specified in two ways:
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Configuration
 
 You can supply a json config to this plugin containing a dictionary. Each key / value will become a property name and
 value on the test suite node of the resulting xml. There is one required config: pytest_zigzag_env_vars.
-This should be a json object that that where the keys are the environment variable names to be collected, if you set
+This should be a json object where the keys are the environment variable names to be collected, if you set
 value to a string that value will be used.  If the value is null it will be pulled from the environment.
 
 The location of the config file can be specified in two ways:

--- a/pytest_zigzag/data/schema/pytest-zigzag-config.schema.json
+++ b/pytest_zigzag/data/schema/pytest-zigzag-config.schema.json
@@ -6,41 +6,8 @@
   "required": ["pytest_zigzag_env_vars"],
   "properties": {
     "pytest_zigzag_env_vars": {
-      "description": "A white list of environment variables to extract and include in the JUnitXML global properties.",
+      "description": "Environment variables to extract and include in the JUnitXML global properties.",
       "type": "object",
-      "properties": {
-        "BUILD_URL": {"type": ["string", "null"]},
-        "BUILD_NUMBER": {"type": ["number", "null"]},
-        "BUILD_ID": {"type": ["string", "null"] },
-        "NODE_NAME": {"type": ["string", "null"] },
-        "JOB_NAME": {"type": ["string", "null"] },
-        "BUILD_TAG": {"type": ["string", "null"] },
-        "JENKINS_URL": {"type": ["string", "null"] },
-        "EXECUTOR_NUMBER": {"type": ["string", "null"]},
-        "WORKSPACE": {"type": ["string", "null"]},
-        "CVS_BRANCH": {"type": ["string", "null"]},
-        "GIT_COMMIT": {"type": ["string", "null"]},
-        "GIT_URL": {"type": ["string", "null"]},
-        "GIT_BRANCH": {"type": ["string", "null"]},
-        "GIT_LOCAL_BRANCH": {"type": ["string", "null"]},
-        "GIT_AUTHOR_NAME": {"type": ["string", "null"]},
-        "GIT_AUTHOR_EMAIL": {"type": ["string", "null"]},
-        "BRANCH_NAME": {"type": ["string", "null"]},
-        "CHANGE_AUTHOR_DISPLAY_NAME": {"type": ["string", "null"]},
-        "CHANGE_AUTHOR": {"type": ["string", "null"]},
-        "CHANGE_BRANCH": {"type": ["string", "null"]},
-        "CHANGE_FORK": {"type": ["string", "null"]},
-        "CHANGE_ID": {"type": ["string", "null"]},
-        "CHANGE_TARGET": {"type": ["string", "null"]},
-        "CHANGE_TITLE": {"type": ["string", "null"]},
-        "CHANGE_URL": {"type": ["string", "null"]},
-        "JOB_URL": {"type": ["string", "null"]},
-        "NODE_LABELS": {"type": ["string", "null"]},
-        "PWD": {"type": ["string", "null"]},
-        "STAGE_NAME": {"type": ["string", "null"]}
-      },
-      "required": ["BUILD_URL", "BUILD_NUMBER"],
-      "minItems": 2,
       "uniqueItems": true
     }
   }

--- a/tests/test_custom_config.py
+++ b/tests/test_custom_config.py
@@ -196,7 +196,7 @@ def test_required_parameters_are_required(testdir, single_decorated_test_functio
     config = \
 """
 {
-  "pytest_zigzag_env_vars": {
+  "not_pytest_zigzag_env_vars": {
     "BUILD_NUMBER": null
   }
 }
@@ -206,19 +206,4 @@ def test_required_parameters_are_required(testdir, single_decorated_test_functio
 
     # Test
     assert "does not comply with schema:" in result[1].stderr.lines[0]
-    assert "'BUILD_URL' is a required property" in result[1].stderr.lines[0]
-
-    config = \
-"""
-{
-  "pytest_zigzag_env_vars": {
-    "BUILD_URL": null
-  }
-}
-""" # noqa
-
-    result = run_and_parse_with_config(testdir, config, exit_code_exp=1)
-
-    # Test
-    assert "does not comply with schema:" in result[1].stderr.lines[0]
-    assert "'BUILD_NUMBER' is a required property" in result[1].stderr.lines[0]
+    assert "'pytest_zigzag_env_vars' is a required property" in result[1].stderr.lines[0]


### PR DESCRIPTION
- loosens the json schema to only validate the object 'pytest_zigzag_env_vars'
- 'pytest_zigzag_env_vars' can contain any environment variables needed by the user
- validation of required configs is handled by the zigzag json schema