### PR TITLE
Maint/master/update run and parse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,11 @@ The location of the config file can be specified in two ways:
 1. In a pytest ini file::
 
     [pytest]
-    config_file=/path/to/config/file
+    pytest-zigzag-config=/path/to/config/file
 
 2. Explicitly on the command line::
 
-    pytest /path/to/test_test.py --config_file=/path/to/config/file
+    pytest /path/to/test_test.py --pytest-zigzag-config=/path/to/config/file
 
 Any property defined in the config file can be overriden by creating an environment variable of the same name. see this `config_property_overrides.md`_
 

--- a/pytest_zigzag/__init__.py
+++ b/pytest_zigzag/__init__.py
@@ -59,10 +59,8 @@ def _capture_config_path(session):
 
         if junit_xml_config:
             # Determine the config option that we should use
-            if _get_option_of_highest_precedence(session.config, 'config_file'):
-                highest_precedence = _get_option_of_highest_precedence(session.config, 'config_file')
-            if _get_option_of_highest_precedence(session.config, 'config_file'):
-                highest_precedence = _get_option_of_highest_precedence(session.config, 'config_file')
+            if _get_option_of_highest_precedence(session.config, 'pytest-zigzag-config'):
+                highest_precedence = _get_option_of_highest_precedence(session.config, 'pytest-zigzag-config')
             if not highest_precedence:
                 highest_precedence = resource_stream('pytest_zigzag', 'data/configs/default-config.json')
 
@@ -251,12 +249,7 @@ def pytest_addoption(parser):
         parser (_pytest.config.Parser): A parser object
     """
 
-    config_option = "pytest-config"
-    config_option_help = "A config file path to be used for the parser."
-    parser.addini(config_option, config_option_help)
-    parser.addoption("--{}".format(config_option), help=config_option_help)
-
-    config_option = "config_file"
+    config_option = "pytest-zigzag-config"
     config_option_help = "The path to a json config file."
     parser.addini(config_option, config_option_help)
     parser.addoption("--{}".format(config_option), help=config_option_help)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,14 +161,11 @@ def run_and_parse_with_config(testdir, config, exit_code_exp=0, runpytest_args=N
 
     runpytest_args = [] if not runpytest_args else runpytest_args
     result_path = testdir.tmpdir.join('junit.xml')
-    config_path = None
+    config_path = testdir.tmpdir.join('conf.json')
     result = None
     with open(str(config_path), 'w') as f:
         f.write(config)
     if ini_config:
-        config_path = testdir.tmpdir.join('conf.json')
-        with open(str(config_path), 'w') as f:
-            f.write(config)
         ini_config_path = testdir.tmpdir.join('pytest.ini')
         # add config path here to match the config file we're about to lay down
         ini_config = ini_config + "config_file=" + str(config_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,28 +123,10 @@ def run_and_parse(testdir, exit_code_exp=0, runpytest_args=None):
 
     junit_xml_doc = JunitXml(str(result_path))
 
-    return (junit_xml_doc, result)
+    return junit_xml_doc, result
 
 
-def build_property_list(config_dict):
-    """ Build a list of properties and values that will end up in junit xml. This should only
-        be used for testing purposes to set expectations.
-
-    Args:
-        config_dict: a python object representation of pytest_zigzag config json
-
-    Returns:
-        props: a flattened dictionary of properties and values
-    """
-    props = {}
-    for root_key in config_dict:
-        if not config_dict[root_key] is None:
-            for key in config_dict[root_key]:
-                props[key] = config_dict[root_key][key]
-    return props
-
-
-def run_and_parse_with_config(testdir, config, exit_code_exp=0, runpytest_args=None):
+def run_and_parse_with_ini_config(testdir, config, exit_code_exp=0, runpytest_args=None):
     """Execute a pytest run against a directory containing pytest Python files.
     Args:
         testdir (_pytest.pytester.TestDir): A pytest fixture for testing pytest plug-ins.
@@ -169,7 +151,25 @@ def run_and_parse_with_config(testdir, config, exit_code_exp=0, runpytest_args=N
 
     junit_xml_doc = JunitXml(str(result_path))
 
-    return (junit_xml_doc, result)
+    return junit_xml_doc, result
+
+
+def build_property_list(config_dict):
+    """ Build a list of properties and values that will end up in junit xml. This should only
+        be used for testing purposes to set expectations.
+
+    Args:
+        config_dict: a python object representation of pytest_zigzag config json
+
+    Returns:
+        props: a flattened dictionary of properties and values
+    """
+    props = {}
+    for root_key in config_dict:
+        if not config_dict[root_key] is None:
+            for key in config_dict[root_key]:
+                props[key] = config_dict[root_key][key]
+    return props
 
 
 def merge_dicts(*args):

--- a/tests/test_custom_config.py
+++ b/tests/test_custom_config.py
@@ -5,7 +5,7 @@
 # ======================================================================================================================
 from __future__ import absolute_import
 import os
-from tests.conftest import run_and_parse, run_and_parse_with_config
+from tests.conftest import run_and_parse, run_and_parse_with_ini_config
 
 
 # ======================================================================================================================
@@ -219,7 +219,7 @@ pytest-zigzag-config={}
 """.format(ini_config_path)  # noqa
 
     args = ["--pytest-zigzag-config", cli_config_path]
-    result = run_and_parse_with_config(testdir, ini_config, 0, args)
+    result = run_and_parse_with_ini_config(testdir, ini_config, 0, args)
 
     # Test
     assert result[0].testsuite_props['FOO'] == 'foo'

--- a/tests/test_testcase.py
+++ b/tests/test_testcase.py
@@ -8,7 +8,7 @@
 from __future__ import absolute_import
 import os
 import pytest
-from tests.conftest import run_and_parse_with_config
+from tests.conftest import run_and_parse
 from dateutil import parser as date_parser
 
 
@@ -28,7 +28,8 @@ def test_uuid_mark_present(testdir, single_decorated_test_function, simple_test_
                                                              mark_arg=test_id_exp,
                                                              test_name=test_name_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert junit_xml.get_testcase_properties(test_name_exp)[mark_type_exp] == test_id_exp
@@ -47,7 +48,8 @@ def test_jira_mark_present(testdir, single_decorated_test_function, simple_test_
                                                              mark_arg=jira_id_exp,
                                                              test_name=test_name_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert junit_xml.get_testcase_properties(test_name_exp)[mark_type_exp] == jira_id_exp
@@ -70,7 +72,8 @@ def test_mark_with_multiple_arguments(testdir, simple_test_config):
                     pass
     """.format(test_name=test_name_exp, **jira_ids_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test (Note: So tox and py.test disagree about the ordering of marks, therefore we sort them first.)
     assert sorted(junit_xml.get_testcase_property(test_name_exp, 'jira')) == sorted(jira_ids_exp.values())
@@ -92,7 +95,8 @@ def test_multiple_marks(testdir, simple_test_config):
                     pass
     """.format(test_name=test_name_exp, **test_ids_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test (Note: So tox and py.test disagree about the ordering of marks, therefore we sort them first.)
     assert sorted(junit_xml.get_testcase_property(test_name_exp, 'test_id')) == sorted(test_ids_exp.values())
@@ -119,7 +123,8 @@ def test_multiple_marks_with_multiple_arguments(testdir, simple_test_config):
                     pass
     """.format(test_name=test_name_exp, **jira_ids_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test (Note: So tox and py.test disagree about the ordering of marks, therefore we sort them first.)
     assert sorted(junit_xml.get_testcase_property(test_name_exp, 'jira')) == sorted(jira_ids_exp.values())
@@ -151,7 +156,8 @@ def test_multiple_test_cases_with_marks_present(testdir, simple_test_config):
 
     testdir.makepyfile(test_py_file.format(**test_info[0]), test_py_file.format(**test_info[1]))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     for info in test_info:
@@ -170,7 +176,8 @@ def test_missing_marks(testdir, undecorated_test_function, simple_test_config):
     # Setup
     testdir.makepyfile(undecorated_test_function.format(test_name=test_name_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert 'test_id' not in junit_xml.get_testcase_properties(test_name_exp).keys()
@@ -187,7 +194,8 @@ def test_start_time(testdir, sleepy_test_function, simple_test_config):
     # Setup
     testdir.makepyfile(sleepy_test_function.format(test_name=test_name_exp, seconds='1'))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert 'start_time' in junit_xml.get_testcase_properties(test_name_exp).keys()
@@ -203,7 +211,8 @@ def test_end_time(testdir, sleepy_test_function, simple_test_config):
     # Setup
     testdir.makepyfile(sleepy_test_function.format(test_name=test_name_exp, seconds='1'))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert 'end_time' in junit_xml.get_testcase_properties(test_name_exp).keys()
@@ -220,7 +229,8 @@ def test_accurate_test_time(testdir, sleepy_test_function, simple_test_config):
     # Setup
     testdir.makepyfile(sleepy_test_function.format(test_name=test_name_exp, seconds=str(sleep_seconds_exp)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     start = date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'start_time')[0]))
@@ -239,7 +249,8 @@ def test_failure_in_setup_fixture(testdir, failure_in_test_setup, simple_test_co
     # Setup
     testdir.makepyfile(failure_in_test_setup.format(test_name=test_name_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config, 1)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 1, args)[0]
 
     try:
         date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'start_time')[0]))
@@ -258,7 +269,8 @@ def test_failure_in_teardown_fixture(testdir, failure_in_test_teardown, simple_t
     # Setup
     testdir.makepyfile(failure_in_test_teardown.format(test_name=test_name_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config, 1)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 1, args)[0]
 
     try:
         date_parser.parse(str(junit_xml.get_testcase_property(test_name_exp, 'start_time')[0]))

--- a/tests/test_testcase_with_steps.py
+++ b/tests/test_testcase_with_steps.py
@@ -6,7 +6,7 @@
 # Imports
 # ======================================================================================================================
 from __future__ import absolute_import
-from tests.conftest import merge_dicts, is_sub_dict, run_and_parse_with_config
+from tests.conftest import merge_dicts, is_sub_dict, run_and_parse
 
 
 # ======================================================================================================================
@@ -27,7 +27,8 @@ def test_class_without_steps(testdir, properly_decorated_test_method, simple_tes
                                                              test_id=test_id_exp,
                                                              jira_id=jira_id_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert junit_xml.get_testcase_properties(test_name_exp)['test_step'] == 'false'
@@ -50,7 +51,8 @@ def test_improperly_decorated_class_without_steps(testdir, improperly_decorated_
                                                                test_id=test_id_exp,
                                                                jira_id=jira_id_exp))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert junit_xml.get_testcase_properties(test_name_exp)['test_step'] == 'false'
@@ -74,7 +76,8 @@ def test_class_with_steps(testdir, properly_decorated_test_class_with_steps, sim
     # Setup
     testdir.makepyfile(properly_decorated_test_class_with_steps.format(**merge_dicts(test_steps, tc_props_exps)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     for test_step in test_steps.values():
@@ -103,7 +106,8 @@ def test_class_with_steps_and_repeated_marks(testdir, improperly_decorated_test_
     # Setup
     testdir.makepyfile(improperly_decorated_test_class_with_steps.format(**merge_dicts(test_steps, tc_props_exps)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     for test_step in test_steps.values():
@@ -130,7 +134,8 @@ def test_class_with_failed_step(testdir, properly_decorated_test_class_with_step
     # Setup
     testdir.makepyfile(properly_decorated_test_class_with_step_failure.format(**merge_dicts(test_steps, tc_props_exps)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config, exit_code_exp=1)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 1, args)[0]
 
     # Test
     assert is_sub_dict(ts_attribs_exps, junit_xml.testsuite_attribs)
@@ -159,7 +164,8 @@ def test_class_with_setup_steps(testdir, properly_decorated_test_class_with_step
     # Setup
     testdir.makepyfile(properly_decorated_test_class_with_step_failure.format(**merge_dicts(test_steps, tc_props_exps)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config, exit_code_exp=1)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 1, args)[0]
 
     # Test
     assert is_sub_dict(ts_attribs_exps, junit_xml.testsuite_attribs)
@@ -188,7 +194,8 @@ def test_class_with_teardown_steps(testdir, properly_decorated_test_class_with_s
     # Setup
     testdir.makepyfile(properly_decorated_test_class_with_step_failure.format(**merge_dicts(test_steps, tc_props_exps)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config, exit_code_exp=1)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 1, args)[0]
 
     # Test
     assert is_sub_dict(ts_attribs_exps, junit_xml.testsuite_attribs)
@@ -220,7 +227,8 @@ def test_class_with_setup_and_teardown_steps(testdir,
     # Setup
     testdir.makepyfile(properly_decorated_test_class_with_step_failure.format(**merge_dicts(test_steps, tc_props_exps)))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config, exit_code_exp=1)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 1, args)[0]
 
     # Test
     assert is_sub_dict(ts_attribs_exps, junit_xml.testsuite_attribs)

--- a/tests/test_testsuite.py
+++ b/tests/test_testsuite.py
@@ -10,7 +10,7 @@ import os
 # noinspection PyProtectedMember
 from pytest_zigzag import _load_config_file
 from pkg_resources import resource_stream
-from tests.conftest import is_sub_dict, run_and_parse_with_config, build_property_list
+from tests.conftest import is_sub_dict, run_and_parse, build_property_list
 
 # ======================================================================================================================
 # Globals
@@ -29,7 +29,8 @@ def test_no_env_vars_set(testdir, undecorated_test_function, testsuite_attribs_e
     # Setup
     testdir.makepyfile(undecorated_test_function.format(test_name='test_pass'))
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert is_sub_dict(testsuite_attribs_exp, junit_xml.testsuite_attribs)
@@ -47,7 +48,8 @@ def test_env_vars_set(testdir, undecorated_test_function, testsuite_attribs_exp,
     for env in ASC_TEST_ENV_VARS:
         os.environ[env] = env
 
-    junit_xml = run_and_parse_with_config(testdir, simple_test_config)[0]
+    args = ["--pytest-zigzag-config", simple_test_config]
+    junit_xml = run_and_parse(testdir, 0, args)[0]
 
     # Test
     assert is_sub_dict(testsuite_attribs_exp, junit_xml.testsuite_attribs)

--- a/tests/test_using_zigzag_inside_pytest.py
+++ b/tests/test_using_zigzag_inside_pytest.py
@@ -29,7 +29,7 @@ def test_zigzag_happy_path(testdir, single_decorated_test_function, mocker):
 
     result = testdir.runpytest(
         "--junitxml={}".format(result_path),
-        "--config_file=./pytest_zigzag/data/configs/default-config.json",
+        "--pytest-zigzag-config=./pytest_zigzag/data/configs/default-config.json",
         "--zigzag",
         "--qtest-project-id={}".format(project_id))
 
@@ -56,7 +56,7 @@ def test_zigzag_no_api_token(testdir, single_decorated_test_function, mocker):
 
     result = testdir.runpytest(
         "--junitxml={}".format(result_path),
-        "--config_file=./pytest_zigzag/data/configs/default-config.json",
+        "--pytest-zigzag-config=./pytest_zigzag/data/configs/default-config.json",
         "--zigzag",
         "--qtest-project-id={}".format(project_id))
 
@@ -86,7 +86,7 @@ def test_zigzag_no_project_id(testdir, single_decorated_test_function, mocker):
 
     result = testdir.runpytest(
         "--junitxml={}".format(result_path),
-        "--config_file=./pytest_zigzag/data/configs/default-config.json",
+        "--pytest-zigzag-config=./pytest_zigzag/data/configs/default-config.json",
         "--zigzag")
 
     # Test
@@ -112,7 +112,7 @@ def test_no_zigzag(testdir, single_decorated_test_function, mocker):
 
     result = testdir.runpytest(
         "--junitxml={}".format(result_path),
-        "--config_file=./pytest_zigzag/data/configs/default-config.json",
+        "--pytest-zigzag-config=./pytest_zigzag/data/configs/default-config.json",
         "--qtest-project-id={}".format(project_id))
 
     # Test

--- a/tests/test_xsd.py
+++ b/tests/test_xsd.py
@@ -10,7 +10,7 @@ from lxml import etree
 # noinspection PyProtectedMember
 # noinspection PyPackageRequirements
 from zigzag.xml_parsing_facade import XmlParsingFacade
-from tests.conftest import run_and_parse_with_config
+from tests.conftest import run_and_parse
 
 
 # ======================================================================================================================
@@ -28,7 +28,9 @@ def test_happy_path_asc(testdir, properly_decorated_test_function, mocker, simpl
                                                                test_id='123e4567-e89b-12d3-a456-426655440000',
                                                                jira_id='ASC-123'))
 
-    xml_doc = run_and_parse_with_config(testdir, simple_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", simple_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
+
     # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd()))
 
@@ -48,7 +50,8 @@ def test_happy_path_mk8s(testdir, properly_decorated_test_function, mocker, mk8s
                                                                test_id='123e4567-e89b-12d3-a456-426655440000',
                                                                jira_id='ASC-123'))
 
-    xml_doc = run_and_parse_with_config(testdir, mk8s_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", mk8s_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
     # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
@@ -74,7 +77,8 @@ def test_multiple_jira_references(testdir, mocker, simple_test_config):
                     pass
     """)
 
-    xml_doc = run_and_parse_with_config(testdir, simple_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", simple_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
     # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd()))
 
@@ -100,7 +104,8 @@ def test_multiple_jira_references_mk8s(testdir, mocker, mk8s_test_config):
                     pass
     """)
 
-    xml_doc = run_and_parse_with_config(testdir, mk8s_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", mk8s_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
     # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
@@ -120,7 +125,8 @@ def test_missing_required_marks_asc(testdir, undecorated_test_function, mocker, 
     # Setup
     testdir.makepyfile(undecorated_test_function.format(test_name='test_typo_global'))
 
-    xml_doc = run_and_parse_with_config(testdir, asc_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", asc_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
     # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('asc')))
 
@@ -140,7 +146,8 @@ def test_missing_required_marks_mk8s(testdir, undecorated_test_function, mocker,
     # Setup
     testdir.makepyfile(undecorated_test_function.format(test_name='test_typo_global'))
 
-    xml_doc = run_and_parse_with_config(testdir, mk8s_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", mk8s_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
     # noinspection PyProtectedMember
     xmlschema = etree.XMLSchema(etree.parse(xmlpf._get_xsd('mk8s')))
 
@@ -161,7 +168,8 @@ def test_extra_testcase_property_asc(testdir, properly_decorated_test_function, 
                                                                test_id='123e4567-e89b-12d3-a456-426655440000',
                                                                jira_id='ASC-123'))
 
-    xml_doc = run_and_parse_with_config(testdir, asc_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", asc_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties').append(etree.Element('property',
@@ -186,7 +194,8 @@ def test_extra_testcase_property_mk8s(testdir, properly_decorated_test_function,
                                                                test_id='123e4567-e89b-12d3-a456-426655440000',
                                                                jira_id='ASC-123'))
 
-    xml_doc = run_and_parse_with_config(testdir, mk8s_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", mk8s_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties').append(etree.Element('property',
@@ -211,7 +220,8 @@ def test_typo_property_asc(testdir, properly_decorated_test_function, mocker, as
                                                                test_id='123e4567-e89b-12d3-a456-426655440000',
                                                                jira_id='ASC-123'))
 
-    xml_doc = run_and_parse_with_config(testdir, asc_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", asc_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties/property').attrib['name'] = 'wrong_test_id'
@@ -235,7 +245,8 @@ def test_typo_property_mk8s(testdir, properly_decorated_test_function, mocker, s
                                                                test_id='123e4567-e89b-12d3-a456-426655440000',
                                                                jira_id='ASC-123'))
 
-    xml_doc = run_and_parse_with_config(testdir, simple_test_config)[0].xml_doc
+    args = ["--pytest-zigzag-config", simple_test_config]
+    xml_doc = run_and_parse(testdir, 0, args)[0].xml_doc
 
     # Add another property element for the testcase.
     xml_doc.find('./testcase/properties/property').attrib['name'] = 'wrong_test_id'


### PR DESCRIPTION
There seemed to be a conflation of the two config files in play with pytest and pytest-zigzag.

- renames CLI option and ini config to both be `pytest-zigzag-config`
- removes `pytest-config` as pytest already has its own ini config logic
- updates tests to use the function `run_and_parse` and rely on the option `--pytest-zigzag-config` to pass the config to zigzag.