### PR TITLE
MAINT manual update version to 1.0.0

### DIFF
--- a/pytest_zigzag/__init__.py
+++ b/pytest_zigzag/__init__.py
@@ -15,7 +15,7 @@ from pkg_resources import resource_stream
 from jsonschema import validate, ValidationError
 from pytest_zigzag.session_messages import SessionMessages
 
-__version__ = '0.2.0'
+__version__ = '1.0.0'
 
 # ======================================================================================================================
 # Globals

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 1.0.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ entry_points = {
 
 setup(
     name='pytest-zigzag',
-    version='0.2.0',
+    version='1.0.0',
     author='rpc-automation',
     author_email='rpc-automation@rackspace.com',
     license='Apache Software License 2.0',


### PR DESCRIPTION
Somehow we acidentally rolled back the version to 0.2.0 the tag of
1.0.0 is correct.  This commit fixes that error.  The original commit
for the version change is a36835a5c390baee351e6ec9e6202064e648c4f5